### PR TITLE
Adds a `match` method for eager loading

### DIFF
--- a/app/BelongsToManyOrOne.php
+++ b/app/BelongsToManyOrOne.php
@@ -72,5 +72,23 @@ class BelongsToManyOrOne extends BelongsToMany
         return $this->wherePivot('preferred', '=', false)->expectMany();
 
     }
+    
+    public function match(array $models, Collection $results, $relation)
+    {
+        $dictionary = $this->buildDictionary($results);
+
+        // Once we have an array dictionary of child objects we can easily match the
+        // children back to their parent using the dictionary and the keys on the
+        // the parent models. Then we will return the hydrated models back out.
+        foreach ($models as $model) {
+            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
+                $model->setRelation(
+                    $relation, $this->isMany ? $this->related->newCollection($dictionary[$key]) : $dictionary[$key]
+                );
+            }
+        }
+
+        return $models;
+    }
 
 }

--- a/app/BelongsToManyOrOne.php
+++ b/app/BelongsToManyOrOne.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Collection;
 
 class BelongsToManyOrOne extends BelongsToMany
 {

--- a/app/BelongsToManyOrOne.php
+++ b/app/BelongsToManyOrOne.php
@@ -78,18 +78,31 @@ class BelongsToManyOrOne extends BelongsToMany
     {
         $dictionary = $this->buildDictionary($results);
 
-        // Once we have an array dictionary of child objects we can easily match the
-        // children back to their parent using the dictionary and the keys on the
-        // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
             if (isset($dictionary[$key = $model->{$this->parentKey}])) {
                 $model->setRelation(
-                    $relation, $this->isMany ? $this->related->newCollection($dictionary[$key]) : $dictionary[$key]
+                    $relation, $this->getRelationValue($dictionary, $key)
                 );
             }
+            else $model->setRelation($relation, $this->getDefaultFor($this->parent));
         }
 
         return $models;
+    }
+    
+    
+    /**
+     * Get the value of a relationship by one or many type.
+     *
+     * @param  array   $dictionary
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function getRelationValue(array $dictionary, $key)
+    {
+        $value = $dictionary[$key];
+
+        return $this->isMany ? $this->related->newCollection($value) : reset($value);
     }
 
 }

--- a/app/BelongsToManyOrOne.php
+++ b/app/BelongsToManyOrOne.php
@@ -84,7 +84,7 @@ class BelongsToManyOrOne extends BelongsToMany
                     $relation, $this->getRelationValue($dictionary, $key)
                 );
             }
-            else $model->setRelation($relation, $this->getDefaultFor($this->parent));
+            else $model->setRelation($relation, null);
         }
 
         return $models;

--- a/app/BelongsToManyOrOne.php
+++ b/app/BelongsToManyOrOne.php
@@ -78,14 +78,9 @@ class BelongsToManyOrOne extends BelongsToMany
     {
         $dictionary = $this->buildDictionary($results);
 
-        foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
-                $model->setRelation(
-                    $relation, $this->getRelationValue($dictionary, $key)
-                );
-            }
-            else $model->setRelation($relation, null);
-        }
+	    foreach ($models as $model) {
+		    $model->setRelation($relation, $this->getRelationValue($dictionary, $model->{$this->parentKey}));
+	    }
 
         return $models;
     }
@@ -100,9 +95,9 @@ class BelongsToManyOrOne extends BelongsToMany
      */
     protected function getRelationValue(array $dictionary, $key)
     {
-        $value = $dictionary[$key];
+        $value = $dictionary[$key] ?? [];
 
-        return $this->isMany ? $this->related->newCollection($value) : reset($value);
+        return $this->isMany ? $this->related->newCollection($value) : (count($value) ? reset($value) : null);
     }
 
 }


### PR DESCRIPTION
I've found this class useful in my own projects. By adding the `match` method you will now get only a single result, not a collection with a single result when eager or lazy loading your relationship when you call `expectOne`.