### PR TITLE
Fix typo in project URL in generated Swagger definition.

### DIFF
--- a/app/Console/Commands/Docs/CreateSwaggerDoc.php
+++ b/app/Console/Commands/Docs/CreateSwaggerDoc.php
@@ -185,7 +185,7 @@ class CreateSwaggerDoc extends AbstractDocCommand
         $doc .= "  },\n";
         $doc .= "  \"externalDocs\": {\n";
         $doc .= "    \"description\": \"See more documentation on our API here:\",\n";
-        $doc .= "    \"url\": \"http://www.github.com/art-insititute-of-chicago/data-aggregator\"\n";
+        $doc .= "    \"url\": \"https://www.github.com/art-institute-of-chicago/data-aggregator\"\n";
         $doc .= "  }\n";
         $doc .= "}\n";
 

--- a/resources/views/swagger.blade.php
+++ b/resources/views/swagger.blade.php
@@ -4600,6 +4600,6 @@
   },
   "externalDocs": {
     "description": "See more documentation on our API here:",
-    "url": "http://www.github.com/art-insititute-of-chicago/data-aggregator"
+    "url": "https://www.github.com/art-institute-of-chicago/data-aggregator"
   }
 }


### PR DESCRIPTION
Hi, I noticed that the project URL in the Swagger definition contained a typo.
I've fixed that and also changed the URL to the HTTPS version.