### PR TITLE
Feature: Add artwork description [API-386]

### DIFF
--- a/app/Transformers/Outbound/Collections/Artwork.php
+++ b/app/Transformers/Outbound/Collections/Artwork.php
@@ -206,7 +206,6 @@ class Artwork extends BaseTransformer
                 'doc' => 'Longer explanation describing the work',
                 'type' => 'string',
                 'elasticsearch' => 'text',
-                'is_restricted' => true,
             ],
             'dimensions' => [
                 'doc' => 'The size, shape, scale, and dimensions of the work. May include multiple dimensions like overall, frame, or dimension for each section of a work. Free-form text formatted in a house style.',

--- a/app/Transformers/Outbound/Collections/Artwork.php
+++ b/app/Transformers/Outbound/Collections/Artwork.php
@@ -10,7 +10,7 @@ use App\Transformers\Outbound\Collections\ArtworkPlacePivot as ArtworkPlacePivot
 use App\Transformers\Outbound\StaticArchive\Site as SiteTransformer;
 
 use App\Transformers\Outbound\Collections\Traits\HasBoosted;
-use App\Transformers\Outbound\Collections\Traits\IsCC0;
+use App\Transformers\Outbound\Collections\Traits\IsCCBy;
 use App\Transformers\Outbound\HasSuggestFields;
 
 use App\Transformers\Outbound\CollectionsTransformer as BaseTransformer;
@@ -19,7 +19,7 @@ use Illuminate\Support\Arr;
 
 class Artwork extends BaseTransformer
 {
-    use IsCC0;
+    use IsCCBy;
     use HasBoosted;
     use HasSuggestFields {
         getSuggestFields as traitGetSuggestFields;

--- a/app/Transformers/Outbound/Collections/Place.php
+++ b/app/Transformers/Outbound/Collections/Place.php
@@ -3,9 +3,14 @@
 namespace App\Transformers\Outbound\Collections;
 
 use App\Transformers\Outbound\CollectionsTransformer as BaseTransformer;
+use App\Transformers\Outbound\Collections\Traits\IsCCBy;
 
 class Place extends BaseTransformer
 {
+    use IsCCBy {
+        IsCCBy::getLicenseText as ccByLicenseText;
+    }
+
     protected function getFields()
     {
         return [
@@ -31,19 +36,6 @@ class Place extends BaseTransformer
 
     public function getLicenseText()
     {
-        return 'The data in this response is licensed under a Creative Commons Attribution 4.0 Generic License (CC-By) and the Terms and Conditions of artic.edu. Contains information from the J. Paul Getty Trust, Getty Research Institute, the Getty Thesaurus of Geographic Names, which is made available under the ODC Attribution License.';
-    }
-
-    public function getLicenseLinks()
-    {
-        return [
-            'https://www.artic.edu/terms',
-            'https://creativecommons.org/licenses/by/4.0/',
-        ];
-    }
-
-    public function getLicensePriority()
-    {
-        return 50;
+        return $this->ccByLicenseText() . ' Contains information from the J. Paul Getty Trust, Getty Research Institute, the Getty Thesaurus of Geographic Names, which is made available under the ODC Attribution License.';
     }
 }

--- a/app/Transformers/Outbound/Collections/Traits/IsCCBy.php
+++ b/app/Transformers/Outbound/Collections/Traits/IsCCBy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Transformers\Outbound\Collections\Traits;
+
+trait IsCCBy
+{
+    public function getLicenseText()
+    {
+        return 'The data in this response is licensed under a Creative Commons Attribution 4.0 Generic License (CC-By) and the Terms and Conditions of artic.edu.';
+    }
+
+    public function getLicenseLinks()
+    {
+        return [
+            'https://creativecommons.org/licenses/by/4.0/',
+            'https://www.artic.edu/terms',
+        ];
+    }
+
+    public function getLicensePriority()
+    {
+        return 50;
+    }
+}

--- a/database/migrations/2023_08_08_161759_update_digital_publications_section_copy_to_longtext.php
+++ b/database/migrations/2023_08_08_161759_update_digital_publications_section_copy_to_longtext.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('digital_publication_sections', function (Blueprint $table) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
         <testsuite name="Contract">
             <directory suffix="Test.php">./tests/Contract</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/tests/Basic/ArtworkTest.php
+++ b/tests/Basic/ArtworkTest.php
@@ -3,17 +3,11 @@
 namespace Tests\Basic;
 
 use App\Models\Collections\Artwork;
-use App\Models\Collections\ArtworkType;
-use App\Models\Collections\Gallery;
 use App\Models\Collections\AgentType;
 use App\Models\Collections\Agent;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
 class ArtworkTest extends BasicTestCase
 {
-    use RefreshDatabase;
-
     protected $model = Artwork::class;
 
     protected $keys = ['id'];
@@ -24,72 +18,5 @@ class ArtworkTest extends BasicTestCase
 
         $agentType = $this->make(AgentType::class, ['title' => 'Individual']);
         $agent = $this->make(Agent::class, ['agent_type_id' => $agentType->id]);
-    }
-
-    /** @test */
-    public function it_fetches_the_gallery_for_an_artwork(): void
-    {
-        $gallery = $this->make(Gallery::class, ['is_closed' => false]);
-        $galleryKey = $gallery->getAttributeValue($gallery->getKeyName());
-
-        $artwork = $this->make(Artwork::class, ['gallery_id' => $galleryKey, 'is_on_view' => true]);
-        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
-
-        $response = $this->getJson('api/v1/artworks/' . $artworkKey);
-        $response->assertSuccessful();
-
-        $resource = $response->json()['data'];
-        $this->assertTrue($resource['is_on_view']);
-    }
-
-    /** @test */
-    public function it_fetches_artwork_linked_art_endpoint(): void
-    {
-        $artworkType = $this->make(ArtworkType::class, ['aat_id' => '300033618', 'title' => 'Painting']);
-        $artworkTypeKey = $artworkType->getAttributeValue($artworkType->getKeyName());
-
-        $artwork = $this->make(Artwork::class, ['artwork_type_id' => $artworkTypeKey]);
-        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
-
-        $response = $this->getJson('la/v1/objects/' . $artworkKey);
-        $response->assertSuccessful();
-
-        $resource = $response->json();
-        $this->assertCount(1, $resource['classified_as']);
-        $this->assertEquals($resource['classified_as'][0]['id'], 'http://vocab.getty.edu/aat/300033618');
-    }
-
-    /** @test */
-    public function it_fetches_multiple_artwork_linked_art_endpoint(): void
-    {
-        $artwork1Type = $this->make(ArtworkType::class, ['aat_id' => '300033618', 'title' => 'Painting']);
-        $artwork1TypeKey = $artwork1Type->getAttributeValue($artwork1Type->getKeyName());
-
-        $artwork1 = $this->make(Artwork::class, ['artwork_type_id' => $artwork1TypeKey]);
-        $artwork1Key = $artwork1->getAttributeValue($artwork1->getKeyName());
-
-        $artwork2Type = $this->make(ArtworkType::class, ['aat_id' => '300193015', 'title' => 'Vessel']);
-        $artwork2TypeKey = $artwork2Type->getAttributeValue($artwork2Type->getKeyName());
-
-        $artwork2 = $this->make(Artwork::class, ['artwork_type_id' => $artwork2TypeKey]);
-        $artwork2Key = $artwork2->getAttributeValue($artwork2->getKeyName());
-
-        $response = $this->getJson('la/v1/objects?ids=' . $artwork1Key . ',' . $artwork2Key);
-        $response->assertSuccessful();
-
-        $resource = $response->json();
-        $this->assertCount(2, $resource['objects']);
-
-        $idsInResponse = array_merge(array_keys($resource['objects'][0]), array_keys($resource['objects'][1]));
-        $this->assertContains($artwork1Key, $idsInResponse, 'The works we added to the database are not in the repsonse');
-
-        $artwork1Response = array_pop($resource['objects'][0]);
-        $artwork2Response = array_pop($resource['objects'][1]);
-        $this->assertCount(1, $artwork1Response['classified_as'], 'The works do not include expected data');
-        $this->assertCount(1, $artwork2Response['classified_as'], 'The works do not include expected data');
-
-        $classifiedIdsInResponse = [$artwork1Response['classified_as'][0]['id'], $artwork2Response['classified_as'][0]['id']];
-        $this->assertContains('http://vocab.getty.edu/aat/300033618', $classifiedIdsInResponse);
-        $this->assertContains('http://vocab.getty.edu/aat/300193015', $classifiedIdsInResponse);
     }
 }

--- a/tests/Basic/DigitalPublicationSectionTest.php
+++ b/tests/Basic/DigitalPublicationSectionTest.php
@@ -9,19 +9,4 @@ class DigitalPublicationSectionTest extends BasicTestCase
     protected $model = DigitalPublicationSection::class;
 
     protected $route = 'digital-publication-sections';
-
-    /** @test */
-    public function it_inserts_long_text_in_the_copy_field(): void
-    {
-        $digitalPublictionSection = $this->make(DigitalPublicationSection::class, ['copy' => fake()->text(66000)]); // Longer than a `text` field
-        $digitalPublictionSectionKey = $digitalPublictionSection->getAttributeValue($digitalPublictionSection->getKeyName());
-
-        $response = $this->getJson('api/v1/digital-publication-sections/' . $digitalPublictionSectionKey);
-        $response->assertSuccessful();
-
-        $resource = $response->json()['data'];
-        $this->assertGreaterThan(65535, strlen($resource['copy']));
-
-        DigitalPublicationSection::query()->delete();
-    }
 }

--- a/tests/Unit/ArtworkTest.php
+++ b/tests/Unit/ArtworkTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Collections\Artwork;
+use App\Models\Collections\ArtworkType;
+use App\Models\Collections\Gallery;
+use App\Models\Collections\AgentType;
+use App\Models\Collections\Agent;
+
+class ArtworkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $agentType = $this->make(AgentType::class, ['title' => 'Individual']);
+        $agent = $this->make(Agent::class, ['agent_type_id' => $agentType->id]);
+    }
+
+    /** @test */
+    public function it_fetches_the_gallery_for_an_artwork(): void
+    {
+        $gallery = $this->make(Gallery::class, ['is_closed' => false]);
+        $galleryKey = $gallery->getAttributeValue($gallery->getKeyName());
+
+        $artwork = $this->make(Artwork::class, ['gallery_id' => $galleryKey, 'is_on_view' => true]);
+        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
+
+        $response = $this->getJson('api/v1/artworks/' . $artworkKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['data'];
+        $this->assertTrue($resource['is_on_view']);
+    }
+
+    /** @test */
+    public function it_fetches_artwork_linked_art_endpoint(): void
+    {
+        $artworkType = $this->make(ArtworkType::class, ['aat_id' => '300033618', 'title' => 'Painting']);
+        $artworkTypeKey = $artworkType->getAttributeValue($artworkType->getKeyName());
+
+        $artwork = $this->make(Artwork::class, ['artwork_type_id' => $artworkTypeKey]);
+        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
+
+        $response = $this->getJson('la/v1/objects/' . $artworkKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json();
+        $this->assertCount(1, $resource['classified_as']);
+        $this->assertEquals($resource['classified_as'][0]['id'], 'http://vocab.getty.edu/aat/300033618');
+    }
+
+    /** @test */
+    public function it_fetches_multiple_artwork_linked_art_endpoint(): void
+    {
+        $artwork1Type = $this->make(ArtworkType::class, ['aat_id' => '300033618', 'title' => 'Painting']);
+        $artwork1TypeKey = $artwork1Type->getAttributeValue($artwork1Type->getKeyName());
+
+        $artwork1 = $this->make(Artwork::class, ['artwork_type_id' => $artwork1TypeKey]);
+        $artwork1Key = $artwork1->getAttributeValue($artwork1->getKeyName());
+
+        $artwork2Type = $this->make(ArtworkType::class, ['aat_id' => '300193015', 'title' => 'Vessel']);
+        $artwork2TypeKey = $artwork2Type->getAttributeValue($artwork2Type->getKeyName());
+
+        $artwork2 = $this->make(Artwork::class, ['artwork_type_id' => $artwork2TypeKey]);
+        $artwork2Key = $artwork2->getAttributeValue($artwork2->getKeyName());
+
+        $response = $this->getJson('la/v1/objects?ids=' . $artwork1Key . ',' . $artwork2Key);
+        $response->assertSuccessful();
+
+        $resource = $response->json();
+        $this->assertCount(2, $resource['objects']);
+
+        $idsInResponse = array_merge(array_keys($resource['objects'][0]), array_keys($resource['objects'][1]));
+        $this->assertContains($artwork1Key, $idsInResponse, 'The works we added to the database are not in the repsonse');
+
+        $artwork1Response = array_pop($resource['objects'][0]);
+        $artwork2Response = array_pop($resource['objects'][1]);
+        $this->assertCount(1, $artwork1Response['classified_as'], 'The works do not include expected data');
+        $this->assertCount(1, $artwork2Response['classified_as'], 'The works do not include expected data');
+
+        $classifiedIdsInResponse = [$artwork1Response['classified_as'][0]['id'], $artwork2Response['classified_as'][0]['id']];
+        $this->assertContains('http://vocab.getty.edu/aat/300033618', $classifiedIdsInResponse);
+        $this->assertContains('http://vocab.getty.edu/aat/300193015', $classifiedIdsInResponse);
+    }
+}

--- a/tests/Unit/ArtworkTest.php
+++ b/tests/Unit/ArtworkTest.php
@@ -89,4 +89,25 @@ class ArtworkTest extends TestCase
         $this->assertContains('http://vocab.getty.edu/aat/300033618', $classifiedIdsInResponse);
         $this->assertContains('http://vocab.getty.edu/aat/300193015', $classifiedIdsInResponse);
     }
+
+    /** @test */
+    public function it_provides_ccby_licensing_details(): void
+    {
+        $artwork = $this->make(Artwork::class);
+        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
+
+        $response = $this->getJson('api/v1/artworks/' . $artworkKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC-By', $resource['license_text']);
+        $this->assertStringNotContainsString('CC0', $resource['license_text']);
+
+        $response = $this->getJson('api/v1/artworks');
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC-By', $resource['license_text']);
+        $this->assertStringNotContainsString('CC0', $resource['license_text']);
+    }
 }

--- a/tests/Unit/ArtworkTest.php
+++ b/tests/Unit/ArtworkTest.php
@@ -110,4 +110,17 @@ class ArtworkTest extends TestCase
         $this->assertStringContainsString('CC-By', $resource['license_text']);
         $this->assertStringNotContainsString('CC0', $resource['license_text']);
     }
+
+    /** @test */
+    public function it_provides_description_field(): void
+    {
+        $artwork = $this->make(Artwork::class, ['description' => fake()->paragraph(5)]);
+        $artworkKey = $artwork->getAttributeValue($artwork->getKeyName());
+
+        $response = $this->getJson('api/v1/artworks/' . $artworkKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['data'];
+        $this->assertNotEmpty($resource['description']);
+    }
 }

--- a/tests/Unit/DigitalPublicationSectionTest.php
+++ b/tests/Unit/DigitalPublicationSectionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Web\DigitalPublicationSection;
+
+class DigitalPublicationSectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_inserts_long_text_in_the_copy_field(): void
+    {
+        $digitalPublictionSection = $this->make(DigitalPublicationSection::class, ['copy' => fake()->text(66000)]); // Longer than a `text` field
+        $digitalPublictionSectionKey = $digitalPublictionSection->getAttributeValue($digitalPublictionSection->getKeyName());
+
+        $response = $this->getJson('api/v1/digital-publication-sections/' . $digitalPublictionSectionKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['data'];
+        $this->assertGreaterThan(65535, strlen($resource['copy']));
+    }
+}

--- a/tests/Unit/PlaceTest.php
+++ b/tests/Unit/PlaceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Collections\Place;
+
+class PlaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_provides_ccby_licensing_details(): void
+    {
+        $place = $this->make(Place::class);
+        $placeKey = $place->getAttributeValue($place->getKeyName());
+
+        $response = $this->getJson('api/v1/places/' . $placeKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC-By', $resource['license_text']);
+        $this->assertStringNotContainsString('CC0', $resource['license_text']);
+        $this->assertStringContainsString('Getty Thesaurus of Geographic Names', $resource['license_text']);
+
+        $response = $this->getJson('api/v1/places');
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC-By', $resource['license_text']);
+        $this->assertStringNotContainsString('CC0', $resource['license_text']);
+        $this->assertStringContainsString('Getty Thesaurus of Geographic Names', $resource['license_text']);
+    }
+}

--- a/tests/Unit/TermTest.php
+++ b/tests/Unit/TermTest.php
@@ -30,4 +30,5 @@ class TermTest extends TestCase
         $resource = $response->json()['info'];
         $this->assertStringContainsString('CC0', $resource['license_text']);
         $this->assertStringNotContainsString('CC-By', $resource['license_text']);
-    }}
+    }
+}

--- a/tests/Unit/TermTest.php
+++ b/tests/Unit/TermTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Collections\Term;
+
+class TermTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_provides_cc0_licensing_details(): void
+    {
+        $term = $this->make(Term::class);
+        $termKey = $term->getAttributeValue($term->getKeyName());
+
+        $response = $this->getJson('api/v1/terms/' . $termKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC0', $resource['license_text']);
+        $this->assertStringNotContainsString('CC-By', $resource['license_text']);
+
+        $response = $this->getJson('api/v1/terms');
+        $response->assertSuccessful();
+
+        $resource = $response->json()['info'];
+        $this->assertStringContainsString('CC0', $resource['license_text']);
+        $this->assertStringNotContainsString('CC-By', $resource['license_text']);
+    }}


### PR DESCRIPTION
This PR adds the `description` field to the output of the /artworks endpoint and licenses that endpoint with CC-By.