### PR TITLE
Feature: separate web imports [API-391]

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,22 +32,22 @@ class Kernel extends ConsoleKernel
         $schedule->command('update:cloudfront-ips')
             ->hourly();
 
-        $schedule->command('delete:collections')
-            ->dailyAt('23:00')
-            ->withoutOverlapping(self::FOR_ONE_YEAR)
-            ->sendOutputTo(storage_path('logs/delete-collections-last-run.log'));
-
+        //
+        // Mobile app
         $schedule->command('import:mobile')
             ->dailyAt('23:05')
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-mobile-last-run.log'));
 
+        //
+        // Shop
         $schedule->command('import:products-full', ['--yes'])
             ->dailyAt('23:10')
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-products-full-last-run.log'));
 
-
+        //
+        // Website
         $schedule->command('import:web-full', ['articles', '--yes'])
             ->dailyAt('23:15')
             ->withoutOverlapping(self::FOR_ONE_YEAR)
@@ -123,28 +123,38 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-web-full-staticpages-last-run.log'));
 
-        $schedule->command('import:sites', ['--yes'])
-            ->monthlyOn(1, '03:00')
-            ->sendOutputTo(storage_path('logs/import-sites-last-run.log'));
-
-        $schedule->command('import:dsc', ['--yes'])
-            ->monthlyOn(1, '03:05')
-            ->sendOutputTo(storage_path('logs/import-dsc-last-run.log'));
-
-        $schedule->command('import:analytics')
-            ->monthlyOn(1, '03:10')
-            ->sendOutputTo(storage_path('logs/import-analytics-last-run.log'));
-
         $schedule->command('import:web')
             ->everyFiveMinutes()
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-web-last-run.log'));
 
+        //
+        // Archived Static sites
+        $schedule->command('import:sites', ['--yes'])
+            ->monthlyOn(1, '03:00')
+            ->sendOutputTo(storage_path('logs/import-sites-last-run.log'));
+
+        //
+        // Digital scholarly catalogues
+        $schedule->command('import:dsc', ['--yes'])
+            ->monthlyOn(1, '03:05')
+            ->sendOutputTo(storage_path('logs/import-dsc-last-run.log'));
+
+        //
+        // Google Analytics
+        $schedule->command('import:analytics')
+            ->monthlyOn(1, '03:10')
+            ->sendOutputTo(storage_path('logs/import-analytics-last-run.log'));
+
+        //
+        // Ticketed events
         $schedule->command('import:events-ticketed-full', ['--unreset'])
             ->everyFiveMinutes()
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-events-ticketed-last-run.log'));
 
+        //
+        // Collections and DAMS
         $schedule->command('delete:assets')
             ->everyFiveMinutes()
             ->withoutOverlapping(self::FOR_ONE_YEAR)
@@ -165,11 +175,15 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-collections-last-run.log'));
 
+        //
+        // Virtual lines
         $schedule->command('import:queues')
             ->everyMinute()
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-queues-last-run.log'));
 
+        //
+        // Data enhancer
         $schedule->command('import:enhancer')
             ->everyMinute()
             ->withoutOverlapping(self::FOR_ONE_YEAR)

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -47,10 +47,81 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping(self::FOR_ONE_YEAR)
             ->sendOutputTo(storage_path('logs/import-products-full-last-run.log'));
 
-        $schedule->command('import:web-full', ['--yes'])
+
+        $schedule->command('import:web-full', ['articles', '--yes'])
             ->dailyAt('23:15')
             ->withoutOverlapping(self::FOR_ONE_YEAR)
-            ->sendOutputTo(storage_path('logs/import-web-full-last-run.log'));
+            ->sendOutputTo(storage_path('logs/import-web-full-articles-last-run.log'));
+
+        $schedule->command('import:web-full', ['artworks', '--yes'])
+            ->dailyAt('23:18')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-artworks-last-run.log'));
+
+        $schedule->command('import:web-full', ['artists', '--yes'])
+            ->dailyAt('23:21')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-artists-last-run.log'));
+
+        $schedule->command('import:web-full', ['events', '--yes'])
+            ->dailyAt('23:24')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-events-last-run.log'));
+
+        $schedule->command('import:web-full', ['event-occurrences', '--yes'])
+            ->dailyAt('23:27')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-event-occurrences-last-run.log'));
+
+        $schedule->command('import:web-full', ['event-programs', '--yes'])
+            ->dailyAt('23:30')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-event-programs-last-run.log'));
+
+        $schedule->command('import:web-full', ['exhibitions', '--yes'])
+            ->dailyAt('23:33')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-exhibitions-last-run.log'));
+
+        $schedule->command('import:web-full', ['highlights', '--yes'])
+            ->dailyAt('23:36')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-highlights-last-run.log'));
+
+        $schedule->command('import:web-full', ['genericpages', '--yes'])
+            ->dailyAt('23:39')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-genericpages-last-run.log'));
+
+        $schedule->command('import:web-full', ['pressreleases', '--yes'])
+            ->dailyAt('23:42')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-pressreleases-last-run.log'));
+
+        $schedule->command('import:web-full', ['educatorresources', '--yes'])
+            ->dailyAt('23:45')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-educatorresources-last-run.log'));
+
+        $schedule->command('import:web-full', ['digitalpublications', '--yes'])
+            ->dailyAt('23:48')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-digitalpublications-last-run.log'));
+
+        $schedule->command('import:web-full', ['digitalpublicationsections', '--yes'])
+            ->dailyAt('23:51')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-digitalpublicationsections-last-run.log'));
+
+        $schedule->command('import:web-full', ['printedpublications', '--yes'])
+            ->dailyAt('23:54')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-printedpublications-last-run.log'));
+
+        $schedule->command('import:web-full', ['staticpages', '--yes'])
+            ->dailyAt('23:57')
+            ->withoutOverlapping(self::FOR_ONE_YEAR)
+            ->sendOutputTo(storage_path('logs/import-web-full-staticpages-last-run.log'));
 
         $schedule->command('import:sites', ['--yes'])
             ->monthlyOn(1, '03:00')


### PR DESCRIPTION
We have a considerable `import:web-full` console command that imports all web content into the API. It's structured to delete all local website content and import each type of data type-by-type. The downside to this logical structure is that we'll be left with many empty tables if an early import breaks. 

This PR breaks up web imports into separate calls for each type so that if one breaks, its impact is limited.