### PR TITLE
Remove 'nocache.' from exhibition web_urls

### DIFF
--- a/app/Models/Web/Exhibition.php
+++ b/app/Models/Web/Exhibition.php
@@ -3,6 +3,8 @@
 namespace App\Models\Web;
 
 use App\Models\WebModel;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Str;
 
 /**
  * An enhanced exhibition on the website
@@ -20,6 +22,13 @@ class Exhibition extends WebModel
     protected $touches = [
         'exhibition',
     ];
+
+    protected function webUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn (?string $webUrl) => $webUrl ? Str::replace('nocache.', '', $webUrl) : null,
+        );
+    }
 
     public function exhibition()
     {

--- a/database/factories/Web/ExhibitionFactory.php
+++ b/database/factories/Web/ExhibitionFactory.php
@@ -2,11 +2,13 @@
 
 namespace Database\Factories\Web;
 
+use App\Models\Web\Exhibition;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 class ExhibitionFactory extends Factory
 {
-    protected $model = \App\Models\Web\Exhibition::class;
+    protected $model = Exhibition::class;
 
     public function definition(): array
     {
@@ -15,5 +17,14 @@ class ExhibitionFactory extends Factory
             'title' => ucfirst(fake()->words(3, true)),
             'datahub_id' => fake()->unique()->randomNumber(4),
         ];
+    }
+
+    public function withNocacheUrl(): static
+    {
+        return $this->state(fn() => [])
+            ->afterMaking(function (Exhibition $exhibition) {
+                $exhibition->web_url =
+                    "https://nocache.www.artic.edu/exhibitions/{$exhibition->id}/" . Str::slug($exhibition->title);
+            });
     }
 }

--- a/tests/Unit/ExhibitionTest.php
+++ b/tests/Unit/ExhibitionTest.php
@@ -2,14 +2,10 @@
 
 namespace Tests\Unit;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\Collections\Exhibition;
-use App\Models\Collections\ArtworkType;
-use App\Models\Collections\Gallery;
-use App\Models\Collections\AgentType;
-use App\Models\Collections\Agent;
 use App\Models\Web\Exhibition as WebExhibition;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class ExhibitionTest extends TestCase
 {
@@ -27,5 +23,19 @@ class ExhibitionTest extends TestCase
 
         $resource = $response->json()['data'];
         $this->assertEquals(4, $resource['position']);
+    }
+
+    /** @test */
+    public function it_does_not_use_nocache_in_web_url_field(): void
+    {
+        $exhibition = $this->make(Exhibition::class);
+        $exhibitionKey = $exhibition->getAttributeValue($exhibition->getKeyName());
+        WebExhibition::factory()->withNocacheUrl()->create(['datahub_id' => $exhibitionKey]);
+
+        $response = $this->getJson('api/v1/exhibitions/' . $exhibitionKey);
+        $response->assertSuccessful();
+
+        $resource = $response->json()['data'];
+        $this->assertStringNotContainsString('nocache.', $resource['web_url']);
     }
 }


### PR DESCRIPTION
This change ensures that exhibitions do not include 'nocache.' in the `web_url` field.