### PR TITLE
Remove invalid boolean check [WEB-3134]

### DIFF
--- a/app/Http/Search/Request.php
+++ b/app/Http/Search/Request.php
@@ -661,7 +661,7 @@ class Request
         $params['body']['query']['script_score']['script'] = [
             'source' => <<<'SOURCE'
                 double vector_score = 0;
-                if (doc.containsKey('text_embedding') && doc['text_embedding'] && doc['text_embedding'].size() > 0 && params.query_vector != null && params.query_vector.length > 0) {
+                if (doc.containsKey('text_embedding') && doc['text_embedding'].size() > 0 && params.query_vector != null && params.query_vector.length > 0) {
                     vector_score = cosineSimilarity(params.query_vector, 'text_embedding') + 1.0;
                 }
 


### PR DESCRIPTION
Removed the `&& doc['text_embedding']` as the Painless scripting language does not consider this a boolean.