### PR TITLE
Add git config for "dubious" directory [API-428]

### DIFF
--- a/app/Console/Commands/Dump/DumpUpload.php
+++ b/app/Console/Commands/Dump/DumpUpload.php
@@ -38,7 +38,7 @@ class DumpUpload extends AbstractDumpCommand
         $this->shell->passthru('rm -rf %s', $repoPath);
         $this->shell->passthru('mkdir %s', $repoPath);
         $this->shell->passthru('git -C %s init', $repoPath);
-
+        $this->shell->passthru('git config --global --add safe.directory %s', $repoPath);
         $this->shell->passthru('git -C %s remote add origin %s', $repoPath, $repoRemote);
 
         // Copy README into the repo


### PR DESCRIPTION
This is to address the error we saw when trying to push from the `dumps` storage:
```
fatal: detected dubious ownership in repository at '/var/www/data-aggregator/shared/storage/dumps/remote'
To add an exception for this directory, call:

        git config --global --add safe.directory /var/www/data-aggregator/shared/storage/dumps/remote
```