### PR TITLE
Cache IIIF info specs in Cloudflare [Gen-AI, Claude-Sonnet-5] [WEB-3491]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,11 @@ PROXY_SCHEME=
 # Fix for cache if in non-standard location:
 HOME=
 
+# For pushing IIIF image geometry to the Cloudflare Worker allowlist's KV store:
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_KV_NAMESPACE_ID=
+
 # TODO: Use `php artisan dump:download` to download a copy of our data:
 DUMP_REPO_REMOTE='git@github.com:art-institute-of-chicago/aic-data.git'
 DUMP_REPO_NAME=

--- a/app/Console/Commands/Import/ImportAssetsFull.php
+++ b/app/Console/Commands/Import/ImportAssetsFull.php
@@ -42,6 +42,10 @@ class ImportAssetsFull extends AbstractImportCommand
         $model = $this->getModelForEndpoint($endpoint);
 
         $this->import('assets', $model, $endpoint, $page);
+
+        if ($endpoint === 'images') {
+            $this->call('import:assets-iiif-geometry');
+        }
     }
 
     protected function getModelForEndpoint($endpoint)

--- a/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
+++ b/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands\Import;
+
+use Aic\Hub\Foundation\AbstractCommand as BaseCommand;
+use App\Models\Collections\Asset;
+use App\Models\Collections\Image;
+use App\Services\CloudflareKvService;
+use App\Services\IiifGeometryService;
+use Illuminate\Support\Facades\Http;
+
+class ImportAssetsIiifGeometry extends BaseCommand
+{
+    protected $signature = 'import:assets-iiif-geometry
+                            {--full : Re-sync every image, not just new/stale ones}
+                            {--chunk=200 : Rows per batch (also the Http::pool concurrency)}
+                            {--dry-run : Skip the Cloudflare KV push}';
+
+    protected $description = 'Fetches IIIF info.json geometry for images, pushes it to the Cloudflare KV store';
+
+    protected CloudflareKvService $kv;
+
+    public function __construct(CloudflareKvService $kv)
+    {
+        parent::__construct();
+
+        $this->kv = $kv;
+    }
+
+    public function handle()
+    {
+        $query = Image::query();
+
+        if (!$this->option('full')) {
+            $query->where(function ($q) {
+                $q->whereNull('iiif_synced_at')
+                    ->orWhereColumn('updated_at', '>', 'iiif_synced_at');
+            });
+        }
+
+        $total = $query->count();
+        $this->info("Syncing IIIF geometry for {$total} image(s)...");
+
+        $processed = 0;
+        $kvBuffer = [];
+
+        $query->chunkById((int) $this->option('chunk'), function ($images) use (&$processed, &$kvBuffer, $total) {
+            // Fetch every image's info.json in this chunk concurrently.
+            $responses = Http::pool(fn ($pool) => $images->map(
+                fn ($image) => $pool->as((string) $image->id)
+                    ->timeout(IiifGeometryService::TIMEOUT_SECONDS)
+                    ->retry(IiifGeometryService::MAX_RETRIES, 500, throw: false)
+                    ->get($image->iiif_url . '/info.json')
+            ));
+
+            foreach ($images as $image) {
+                $response = $responses[(string) $image->id];
+
+                if (!$response->successful()) {
+                    $this->warn("  info.json failed for #{$image->id}: " . $response->status());
+                    continue;
+                }
+
+                $info = $response->json();
+                $tile = $info['tiles'][0] ?? null;
+
+                $image->width = $info['width'] ?? null;
+                $image->height = $info['height'] ?? null;
+                $image->tile_width = $tile['width'] ?? null;
+                $image->tile_height = $tile['height'] ?? null;
+                $image->scale_factors = $tile['scaleFactors'] ?? null;
+                $image->iiif_synced_at = now();
+                $image->save();
+
+                $kvBuffer[] = [
+                    'key' => Asset::getHashedId($image->id),
+                    'value' => json_encode([
+                        'w' => $image->width,
+                        'h' => $image->height,
+                        'tw' => $image->tile_width,
+                        'th' => $image->tile_height,
+                        'sf' => $image->scale_factors,
+                        'tiled' => (bool) $tile,
+                        'crawledAt' => $image->iiif_synced_at->toIso8601String(),
+                    ]),
+                ];
+            }
+
+            $processed += $images->count();
+            $this->info("  {$processed}/{$total} processed");
+
+            if (count($kvBuffer) >= 5000) {
+                $this->flushToKv($kvBuffer);
+                $kvBuffer = [];
+            }
+        });
+
+        if ($kvBuffer) {
+            $this->flushToKv($kvBuffer);
+        }
+    }
+
+    private function flushToKv(array $entries)
+    {
+        if ($this->option('dry-run')) {
+            $this->info('  [dry-run] would push ' . count($entries) . ' KV entries');
+            return;
+        }
+
+        $this->kv->bulkPut($entries);
+        $this->info('  pushed ' . count($entries) . ' KV entries');
+    }
+}

--- a/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
+++ b/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
@@ -21,13 +21,9 @@ class ImportAssetsIiifGeometry extends BaseCommand
 
     protected $zeroTrustAuth = true;
 
-    protected CloudflareKvService $kv;
-
-    public function __construct(CloudflareKvService $kv)
+    public function __construct(protected CloudflareKvService $kv)
     {
         parent::__construct();
-
-        $this->kv = $kv;
     }
 
     public function handle()

--- a/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
+++ b/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
@@ -19,6 +19,8 @@ class ImportAssetsIiifGeometry extends BaseCommand
 
     protected $description = 'Fetches IIIF info.json geometry for images, pushes it to the Cloudflare KV store';
 
+    protected $zeroTrustAuth = true;
+
     protected CloudflareKvService $kv;
 
     public function __construct(CloudflareKvService $kv)
@@ -51,6 +53,10 @@ class ImportAssetsIiifGeometry extends BaseCommand
                 fn ($image) => $pool->as((string) $image->id)
                     ->timeout(IiifGeometryService::TIMEOUT_SECONDS)
                     ->retry(IiifGeometryService::MAX_RETRIES, 500, throw: false)
+                    ->when($this->zeroTrustAuth, fn ($request) => $request->withHeaders([
+                        'CF-Access-Client-Id' => config('aic.web.zerotrust_client_id'),
+                        'CF-Access-Client-Secret' => config('aic.web.zerotrust_client_secret'),
+                    ]))
                     ->get($image->iiif_url . '/info.json')
             ));
 

--- a/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
+++ b/app/Console/Commands/Import/ImportAssetsIiifGeometry.php
@@ -8,6 +8,7 @@ use App\Models\Collections\Image;
 use App\Services\CloudflareKvService;
 use App\Services\IiifGeometryService;
 use Illuminate\Support\Facades\Http;
+use Throwable;
 
 class ImportAssetsIiifGeometry extends BaseCommand
 {
@@ -55,6 +56,11 @@ class ImportAssetsIiifGeometry extends BaseCommand
 
             foreach ($images as $image) {
                 $response = $responses[(string) $image->id];
+
+                if ($response instanceof Throwable) {
+                    $this->warn("  info.json failed for #{$image->id}: " . $response->getMessage());
+                    continue;
+                }
 
                 if (!$response->successful()) {
                     $this->warn("  info.json failed for #{$image->id}: " . $response->status());

--- a/app/Models/Collections/Image.php
+++ b/app/Models/Collections/Image.php
@@ -13,6 +13,11 @@ class Image extends Asset
 
     protected $appends = ['iiif_url'];
 
+    protected $casts = [
+        'scale_factors' => 'array',
+        'iiif_synced_at' => 'datetime',
+    ];
+
     /**
      * Get the IIIF URL. Corresponds to the `@id` attribute in the image's `/info.json`
      *

--- a/app/Models/Collections/Image.php
+++ b/app/Models/Collections/Image.php
@@ -25,7 +25,7 @@ class Image extends Asset
      */
     public function getIiifUrlAttribute()
     {
-        return config('aic.assets.iiif_url') . '/' . Asset::getHashedId($this->id);
+        return config('aic.asset.iiif_url') . '/' . Asset::getHashedId($this->id);
     }
 
     public function searchableImage()

--- a/app/Services/CloudflareKvService.php
+++ b/app/Services/CloudflareKvService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Exception;
+
+class CloudflareKvService
+{
+    public function bulkPut(array $entries): void
+    {
+        $accountId = config('services.cloudflare.account_id');
+        $namespaceId = config('services.cloudflare.kv_namespace_id');
+        $token = config('services.cloudflare.api_token');
+
+        $url = "https://api.cloudflare.com/client/v4/accounts/{$accountId}/storage/kv/namespaces/{$namespaceId}/bulk";
+
+        $response = Http::withToken($token)->put($url, $entries);
+
+        if (!$response->successful()) {
+            throw new Exception('Cloudflare KV bulk write failed: ' . $response->status() . ' ' . $response->body());
+        }
+    }
+}

--- a/app/Services/IiifGeometryService.php
+++ b/app/Services/IiifGeometryService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class IiifGeometryService
+{
+    public const MAX_RETRIES = 3;
+    public const TIMEOUT_SECONDS = 10;
+
+    /**
+     * Fetches and parses `{iiifUrl}/info.json`, returning geometry fields
+     * ready to assign onto an Image model, or null if the identifier has
+     * no reachable info.json (e.g. asset was deleted/never digitized).
+     */
+    public function fetch(string $iiifUrl): ?array
+    {
+        $response = Http::timeout(self::TIMEOUT_SECONDS)
+            ->retry(self::MAX_RETRIES, 500, throw: false)
+            ->get($iiifUrl . '/info.json');
+
+        if (!$response->successful()) {
+            return null;
+        }
+
+        $info = $response->json();
+        $tile = $info['tiles'][0] ?? null;
+
+        return [
+            'width' => $info['width'] ?? null,
+            'height' => $info['height'] ?? null,
+            'tile_width' => $tile['width'] ?? null,
+            'tile_height' => $tile['height'] ?? null,
+            'scale_factors' => $tile['scaleFactors'] ?? null,
+        ];
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,10 @@ return [
         ],
     ],
 
+    'cloudflare' => [
+        'account_id' => env('CLOUDFLARE_ACCOUNT_ID'),
+        'api_token' => env('CLOUDFLARE_API_TOKEN'),
+        'kv_namespace_id' => env('CLOUDFLARE_KV_NAMESPACE_ID'),
+    ],
+
 ];

--- a/database/migrations/2026_09_03_000000_add_iiif_geometry_fields_to_assets.php
+++ b/database/migrations/2026_09_03_000000_add_iiif_geometry_fields_to_assets.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->unsignedSmallInteger('tile_width')->nullable()->after('height');
+            $table->unsignedSmallInteger('tile_height')->nullable()->after('tile_width');
+            $table->json('scale_factors')->nullable()->after('tile_height');
+            $table->timestamp('iiif_synced_at')->nullable()->after('scale_factors');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropColumn(['tile_width', 'tile_height', 'scale_factors', 'iiif_synced_at']);
+        });
+    }
+};

--- a/tests/Unit/CloudflareKvServiceTest.php
+++ b/tests/Unit/CloudflareKvServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Support\Facades\Http;
+use App\Services\CloudflareKvService;
+use Exception;
+
+class CloudflareKvServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'services.cloudflare.account_id' => 'acct-123',
+            'services.cloudflare.kv_namespace_id' => 'ns-456',
+            'services.cloudflare.api_token' => 'token-789',
+        ]);
+    }
+
+    #[Test]
+    public function it_bulk_puts_entries_to_the_correct_endpoint_with_the_expected_body(): void
+    {
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response(['success' => true]),
+        ]);
+
+        $entries = [
+            ['key' => 'abc-123', 'value' => '{"w":100}'],
+            ['key' => 'def-456', 'value' => '{"w":200}'],
+        ];
+
+        (new CloudflareKvService())->bulkPut($entries);
+
+        $expectedUrl = 'https://api.cloudflare.com/client/v4/accounts/acct-123/storage/kv/namespaces/ns-456/bulk';
+
+        Http::assertSent(function ($request) use ($entries, $expectedUrl) {
+            return $request->url() === $expectedUrl
+                && $request->method() === 'PUT'
+                && $request->hasHeader('Authorization', 'Bearer token-789')
+                && $request->data() === $entries;
+        });
+    }
+
+    #[Test]
+    public function it_throws_when_the_response_is_not_successful(): void
+    {
+        Http::fake([
+            'api.cloudflare.com/*' => Http::response(['success' => false], 500),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Cloudflare KV bulk write failed: 500/');
+
+        (new CloudflareKvService())->bulkPut([['key' => 'abc-123', 'value' => '{}']]);
+    }
+}

--- a/tests/Unit/CloudflareKvServiceTest.php
+++ b/tests/Unit/CloudflareKvServiceTest.php
@@ -22,30 +22,6 @@ class CloudflareKvServiceTest extends TestCase
     }
 
     #[Test]
-    public function it_bulk_puts_entries_to_the_correct_endpoint_with_the_expected_body(): void
-    {
-        Http::fake([
-            'api.cloudflare.com/*' => Http::response(['success' => true]),
-        ]);
-
-        $entries = [
-            ['key' => 'abc-123', 'value' => '{"w":100}'],
-            ['key' => 'def-456', 'value' => '{"w":200}'],
-        ];
-
-        (new CloudflareKvService())->bulkPut($entries);
-
-        $expectedUrl = 'https://api.cloudflare.com/client/v4/accounts/acct-123/storage/kv/namespaces/ns-456/bulk';
-
-        Http::assertSent(function ($request) use ($entries, $expectedUrl) {
-            return $request->url() === $expectedUrl
-                && $request->method() === 'PUT'
-                && $request->hasHeader('Authorization', 'Bearer token-789')
-                && $request->data() === $entries;
-        });
-    }
-
-    #[Test]
     public function it_throws_when_the_response_is_not_successful(): void
     {
         Http::fake([

--- a/tests/Unit/IiifGeometryServiceTest.php
+++ b/tests/Unit/IiifGeometryServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Support\Facades\Http;
+use App\Services\IiifGeometryService;
+
+class IiifGeometryServiceTest extends TestCase
+{
+    #[Test]
+    public function it_parses_geometry_from_a_successful_info_json(): void
+    {
+        Http::fake([
+            'https://example.com/iiif/2/some-id/info.json' => Http::response([
+                'width' => 557,
+                'height' => 768,
+                'tiles' => [
+                    ['width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8]],
+                ],
+            ]),
+        ]);
+
+        $result = (new IiifGeometryService())->fetch('https://example.com/iiif/2/some-id');
+
+        $this->assertSame([
+            'width' => 557,
+            'height' => 768,
+            'tile_width' => 256,
+            'tile_height' => 256,
+            'scale_factors' => [1, 2, 4, 8],
+        ], $result);
+    }
+
+    #[Test]
+    public function it_returns_null_when_the_request_fails(): void
+    {
+        Http::fake([
+            'https://example.com/iiif/2/missing-id/info.json' => Http::response(null, 404),
+        ]);
+
+        $result = (new IiifGeometryService())->fetch('https://example.com/iiif/2/missing-id');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function it_returns_null_on_a_server_error(): void
+    {
+        Http::fake([
+            'https://example.com/iiif/2/broken-id/info.json' => Http::response(null, 500),
+        ]);
+
+        $result = (new IiifGeometryService())->fetch('https://example.com/iiif/2/broken-id');
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/IiifGeometryServiceTest.php
+++ b/tests/Unit/IiifGeometryServiceTest.php
@@ -9,17 +9,19 @@ use App\Services\IiifGeometryService;
 
 class IiifGeometryServiceTest extends TestCase
 {
+    public const JSON_RESPONSE = [
+        'width' => 557,
+        'height' => 768,
+        'tiles' => [
+            ['width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8]],
+        ],
+    ];
+
     #[Test]
     public function it_parses_geometry_from_a_successful_info_json(): void
     {
         Http::fake([
-            'https://example.com/iiif/2/some-id/info.json' => Http::response([
-                'width' => 557,
-                'height' => 768,
-                'tiles' => [
-                    ['width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8]],
-                ],
-            ]),
+            'https://example.com/iiif/2/some-id/info.json' => Http::response(self::JSON_RESPONSE),
         ]);
 
         $result = (new IiifGeometryService())->fetch('https://example.com/iiif/2/some-id');

--- a/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
+++ b/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use App\Models\Collections\Image;
+
+class ImportAssetsIiifGeometryCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['aic.assets.iiif_url' => 'https://example.com/iiif/2']);
+    }
+
+    private function fakeInfoJsonResponse(): array
+    {
+        return [
+            'width' => 557,
+            'height' => 768,
+            'tiles' => [
+                ['width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8]],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function it_only_fetches_new_or_stale_images_by_default(): void
+    {
+        $new = $this->make(Image::class);
+
+        $upToDate = $this->make(Image::class);
+        DB::table('assets')->where('id', $upToDate->id)->update([
+            'iiif_synced_at' => now()->subHour(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+        $stale = $this->make(Image::class);
+        DB::table('assets')->where('id', $stale->id)->update([
+            'iiif_synced_at' => now()->subDay(),
+            'updated_at' => now(),
+        ]);
+
+        Http::fake([
+            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+        ]);
+
+        $this->artisan('import:assets-iiif-geometry', ['--dry-run' => true])
+            ->assertSuccessful();
+
+        Http::assertSentCount(2);
+
+        Http::assertSent(fn ($request) => $request->url() === $new->iiif_url . '/info.json');
+        Http::assertSent(fn ($request) => $request->url() === $stale->iiif_url . '/info.json');
+        Http::assertNotSent(fn ($request) => $request->url() === $upToDate->iiif_url . '/info.json');
+
+        $new->refresh();
+        $this->assertSame(557, $new->width);
+        $this->assertSame(768, $new->height);
+        $this->assertSame(256, $new->tile_width);
+        $this->assertSame(256, $new->tile_height);
+        $this->assertSame([1, 2, 4, 8], $new->scale_factors);
+        $this->assertNotNull($new->iiif_synced_at);
+    }
+
+    #[Test]
+    public function it_resyncs_every_image_with_the_full_flag(): void
+    {
+        $upToDate = $this->make(Image::class);
+        DB::table('assets')->where('id', $upToDate->id)->update([
+            'iiif_synced_at' => now()->subHour(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+        Http::fake([
+            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+        ]);
+
+        $this->artisan('import:assets-iiif-geometry', ['--full' => true, '--dry-run' => true])
+            ->assertSuccessful();
+
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function it_does_not_push_to_cloudflare_kv_on_a_dry_run(): void
+    {
+        $this->make(Image::class);
+
+        Http::fake([
+            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+            'api.cloudflare.com/*' => Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('import:assets-iiif-geometry', ['--dry-run' => true])
+            ->assertSuccessful();
+
+        Http::assertNotSent(fn ($request) => str_contains($request->url(), 'api.cloudflare.com'));
+    }
+}

--- a/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
+++ b/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
@@ -4,46 +4,36 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use App\Models\Collections\Image;
 
 class ImportAssetsIiifGeometryCommandTest extends TestCase
 {
+    protected $upToDate;
+
+    protected $stale;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        config(['aic.asset.iiif_url' => 'https://example.com/iiif/2']);
-    }
+        $this->upToDate = $this->make(Image::class, [
+            'iiif_synced_at' => now()->subHour(),
+            'updated_at' => now()->subDay(),
+        ]);
 
-    private function fakeInfoJsonResponse(): array
-    {
-        return [
-            'width' => 557,
-            'height' => 768,
-            'tiles' => [
-                ['width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8]],
-            ],
-        ];
+        $this->stale = $this->make(Image::class, [
+            'iiif_synced_at' => now()->subDay(),
+            'updated_at' => now(),
+        ]);
+
+        config(['aic.asset.iiif_url' => 'https://example.com/iiif/2']);
     }
 
     #[Test]
     public function it_only_fetches_new_or_stale_images_by_default(): void
     {
         $new = $this->make(Image::class);
-
-        $upToDate = $this->make(Image::class);
-        DB::table('assets')->where('id', $upToDate->id)->update([
-            'iiif_synced_at' => now()->subHour(),
-            'updated_at' => now()->subDay(),
-        ]);
-
-        $stale = $this->make(Image::class);
-        DB::table('assets')->where('id', $stale->id)->update([
-            'iiif_synced_at' => now()->subDay(),
-            'updated_at' => now(),
-        ]);
 
         Http::fake([
             '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
@@ -55,8 +45,8 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
         Http::assertSentCount(2);
 
         Http::assertSent(fn ($request) => $request->url() === $new->iiif_url . '/info.json');
-        Http::assertSent(fn ($request) => $request->url() === $stale->iiif_url . '/info.json');
-        Http::assertNotSent(fn ($request) => $request->url() === $upToDate->iiif_url . '/info.json');
+        Http::assertSent(fn ($request) => $request->url() === $this->stale->iiif_url . '/info.json');
+        Http::assertNotSent(fn ($request) => $request->url() === $this->upToDate->iiif_url . '/info.json');
 
         $new->refresh();
         $this->assertSame(557, $new->width);
@@ -70,12 +60,6 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
     #[Test]
     public function it_resyncs_every_image_with_the_full_flag(): void
     {
-        $upToDate = $this->make(Image::class);
-        DB::table('assets')->where('id', $upToDate->id)->update([
-            'iiif_synced_at' => now()->subHour(),
-            'updated_at' => now()->subDay(),
-        ]);
-
         Http::fake([
             '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
         ]);
@@ -83,7 +67,7 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
         $this->artisan('import:assets-iiif-geometry', ['--full' => true, '--dry-run' => true])
             ->assertSuccessful();
 
-        Http::assertSentCount(1);
+        Http::assertSentCount(2);
     }
 
     #[Test]

--- a/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
+++ b/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
@@ -14,7 +14,7 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
     {
         parent::setUp();
 
-        config(['aic.assets.iiif_url' => 'https://example.com/iiif/2']);
+        config(['aic.asset.iiif_url' => 'https://example.com/iiif/2']);
     }
 
     private function fakeInfoJsonResponse(): array

--- a/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
+++ b/tests/Unit/ImportAssetsIiifGeometryCommandTest.php
@@ -36,7 +36,7 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
         $new = $this->make(Image::class);
 
         Http::fake([
-            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+            '*/info.json' => Http::response(IiifGeometryServiceTest::JSON_RESPONSE),
         ]);
 
         $this->artisan('import:assets-iiif-geometry', ['--dry-run' => true])
@@ -61,7 +61,7 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
     public function it_resyncs_every_image_with_the_full_flag(): void
     {
         Http::fake([
-            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+            '*/info.json' => Http::response(IiifGeometryServiceTest::JSON_RESPONSE),
         ]);
 
         $this->artisan('import:assets-iiif-geometry', ['--full' => true, '--dry-run' => true])
@@ -76,7 +76,7 @@ class ImportAssetsIiifGeometryCommandTest extends TestCase
         $this->make(Image::class);
 
         Http::fake([
-            '*/info.json' => Http::response($this->fakeInfoJsonResponse()),
+            '*/info.json' => Http::response(IiifGeometryServiceTest::JSON_RESPONSE),
             'api.cloudflare.com/*' => Http::response(['success' => true]),
         ]);
 


### PR DESCRIPTION
This is the first part of the IIIF allowlisting work, which cache's each assets's allowed dimensions in Cloudflare KV storage.