### PR TITLE
Add a 'status' code to the body of the error response [WEB-3472]

### DIFF
--- a/app/Http/Middleware/AIServiceStatus.php
+++ b/app/Http/Middleware/AIServiceStatus.php
@@ -8,7 +8,8 @@ class AIServiceStatus
     {
         if (!config('azure.status', false)) {
             return response()->json([
-                'error' => 'AI services are currently disabled'
+                'status' => 503,
+                'error' => 'AI services are currently disabled',
             ], 503);
         }
 


### PR DESCRIPTION
The API consumer class expects the API to return a `status` in the body of the JSON response if it is an error, see https://github.com/art-institute-of-chicago/data-hub-foundation/blob/develop/src/Library/Api/Consumers/GuzzleApiConsumer.php#L33